### PR TITLE
19-Countdown.Speed.74.Steps

### DIFF
--- a/19-Countdown.speed.asm
+++ b/19-Countdown.speed.asm
@@ -7,9 +7,9 @@ c:
     OUTBOX  
 d:
     INBOX   
+    JUMPZ    a
     COPYTO   0
     JUMPN    f
-    JUMPZ    a
 e:
     OUTBOX  
     BUMPDN   0
@@ -19,7 +19,7 @@ f:
 g:
     OUTBOX  
     BUMPUP   0
+    JUMPN    g
     JUMPZ    c
-    JUMP     g
 
 


### PR DESCRIPTION
A 74 step solution for 19-Countdown faster than previous solution of 79 steps. (Average saving of 5 steps)

Zero check now saves 1 step by not storing value when detected.

Negative logic loop uses a JUMPN as it needs to loop so long as negative, this saves it from needing to check zero like the positive loop. Saves 1 step per the absolute value of the sum of negative numbers. JUMPZ in negative logic is just for show as it could be a normal jump as well.
